### PR TITLE
#48 fix: match test and ignore path patterns by whole components

### DIFF
--- a/src/analysis/mapper.rs
+++ b/src/analysis/mapper.rs
@@ -73,15 +73,11 @@ where
             continue;
         }
 
-        if config.should_ignore(&diff.path) {
-            let pattern = config
-                .classification
-                .ignore_paths
-                .iter()
-                .find(|p| diff.path.to_string_lossy().contains(p.as_str()))
-                .cloned()
-                .unwrap_or_default();
-            scope.add_skipped(diff.path.clone(), ExclusionReason::IgnorePattern(pattern));
+        if let Some(pattern) = config.matched_ignore_pattern(&diff.path) {
+            scope.add_skipped(
+                diff.path.clone(),
+                ExclusionReason::IgnorePattern(pattern.to_string()),
+            );
             continue;
         }
 

--- a/src/classifier/path_classifier.rs
+++ b/src/classifier/path_classifier.rs
@@ -3,6 +3,76 @@
 
 use std::path::Path;
 
+/// Checks whether a path matches a `/`-separated pattern by whole components
+///
+/// The pattern's components must appear consecutively in the path. A trailing
+/// slash requires the match to be a directory, i.e. at least one more path
+/// component must follow. Substrings never match partial components, so
+/// `tests/` does not match `src/attests/mod.rs` and `src/gen` does not match
+/// `src/generic.rs`.
+///
+/// # Arguments
+///
+/// * `path` - Path to check
+/// * `pattern` - `/`-separated component pattern
+///
+/// # Returns
+///
+/// `true` if the pattern's components appear consecutively in the path
+///
+/// # Examples
+///
+/// ```
+/// use std::path::Path;
+///
+/// use rust_diff_analyzer::classifier::path_classifier::path_matches_pattern;
+///
+/// assert!(path_matches_pattern(
+///     Path::new("tests/integration.rs"),
+///     "tests/"
+/// ));
+/// assert!(path_matches_pattern(
+///     Path::new("crate/tests/it.rs"),
+///     "tests/"
+/// ));
+/// assert!(!path_matches_pattern(
+///     Path::new("src/attests/mod.rs"),
+///     "tests/"
+/// ));
+/// assert!(!path_matches_pattern(
+///     Path::new("src/generic.rs"),
+///     "src/gen"
+/// ));
+/// ```
+pub fn path_matches_pattern(path: &Path, pattern: &str) -> bool {
+    let requires_directory = pattern.ends_with('/');
+    let pattern_components: Vec<&str> = pattern.split('/').filter(|c| !c.is_empty()).collect();
+    if pattern_components.is_empty() {
+        return false;
+    }
+
+    let components: Vec<String> = path
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .collect();
+    let needed = pattern_components.len();
+    if components.len() < needed {
+        return false;
+    }
+
+    for start in 0..=(components.len() - needed) {
+        let matches = components[start..start + needed]
+            .iter()
+            .zip(&pattern_components)
+            .all(|(component, pattern_component)| component == pattern_component);
+        if matches && (!requires_directory || start + needed < components.len()) {
+            return true;
+        }
+    }
+
+    false
+}
+
 /// Checks if path is in examples directory
 ///
 /// # Arguments
@@ -24,7 +94,7 @@ use std::path::Path;
 /// assert!(!is_example_path(Path::new("src/lib.rs")));
 /// ```
 pub fn is_example_path(path: &Path) -> bool {
-    path.to_string_lossy().contains("examples/")
+    path_matches_pattern(path, "examples/")
 }
 
 /// Checks if path is in benches directory
@@ -48,7 +118,7 @@ pub fn is_example_path(path: &Path) -> bool {
 /// assert!(!is_bench_path(Path::new("src/lib.rs")));
 /// ```
 pub fn is_bench_path(path: &Path) -> bool {
-    path.to_string_lossy().contains("benches/")
+    path_matches_pattern(path, "benches/")
 }
 
 /// Checks if path is in tests directory
@@ -72,7 +142,7 @@ pub fn is_bench_path(path: &Path) -> bool {
 /// assert!(!is_test_path(Path::new("src/lib.rs")));
 /// ```
 pub fn is_test_path(path: &Path) -> bool {
-    path.to_string_lossy().contains("tests/")
+    path_matches_pattern(path, "tests/")
 }
 
 #[cfg(test)]
@@ -96,5 +166,28 @@ mod tests {
     fn test_test_paths() {
         assert!(is_test_path(Path::new("tests/integration.rs")));
         assert!(!is_test_path(Path::new("src/tests.rs")));
+    }
+
+    #[test]
+    fn test_component_boundaries() {
+        assert!(!is_test_path(Path::new("src/attests/mod.rs")));
+        assert!(!is_test_path(Path::new("src/contests/x.rs")));
+        assert!(!is_bench_path(Path::new("src/benches_util/x.rs")));
+        assert!(is_test_path(Path::new("crate/tests/deep/it.rs")));
+    }
+
+    #[test]
+    fn test_pattern_matching_rules() {
+        assert!(path_matches_pattern(Path::new("src/gen/out.rs"), "src/gen"));
+        assert!(!path_matches_pattern(
+            Path::new("src/generic.rs"),
+            "src/gen"
+        ));
+        assert!(path_matches_pattern(
+            Path::new("src/gen/out.rs"),
+            "src/gen/"
+        ));
+        assert!(!path_matches_pattern(Path::new("a/tests"), "tests/"));
+        assert!(!path_matches_pattern(Path::new("src/lib.rs"), ""));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -371,6 +371,9 @@ impl Config {
 
     /// Checks if a path should be ignored
     ///
+    /// Patterns match whole path components: `src/gen` ignores files under
+    /// `src/gen/` but not `src/generic.rs`.
+    ///
     /// # Arguments
     ///
     /// * `path` - Path to check
@@ -390,11 +393,42 @@ impl Config {
     /// assert!(!config.should_ignore(Path::new("src/lib.rs")));
     /// ```
     pub fn should_ignore(&self, path: &Path) -> bool {
-        let path_str = path.to_string_lossy();
+        self.matched_ignore_pattern(path).is_some()
+    }
+
+    /// Returns the first ignore pattern matching the path, if any
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to check
+    ///
+    /// # Returns
+    ///
+    /// The matching pattern or `None`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::path::Path;
+    ///
+    /// use rust_diff_analyzer::Config;
+    ///
+    /// let mut config = Config::default();
+    /// config
+    ///     .classification
+    ///     .ignore_paths
+    ///     .push("generated/".to_string());
+    /// assert_eq!(
+    ///     config.matched_ignore_pattern(Path::new("generated/api.rs")),
+    ///     Some("generated/")
+    /// );
+    /// ```
+    pub fn matched_ignore_pattern(&self, path: &Path) -> Option<&str> {
         self.classification
             .ignore_paths
             .iter()
-            .any(|p| path_str.contains(p))
+            .find(|p| crate::classifier::path_classifier::path_matches_pattern(path, p))
+            .map(|s| s.as_str())
     }
 
     /// Checks if an author should be ignored
@@ -479,11 +513,10 @@ impl Config {
     /// assert!(!config.is_test_path(Path::new("src/lib.rs")));
     /// ```
     pub fn is_test_path(&self, path: &Path) -> bool {
-        let path_str = path.to_string_lossy();
         self.classification
             .test_paths
             .iter()
-            .any(|p| path_str.contains(p))
+            .any(|p| crate::classifier::path_classifier::path_matches_pattern(path, p))
     }
 
     /// Checks if path is a build script


### PR DESCRIPTION
Closes #48

Follow-up to #41, split out to respect PR size limits.

## What

- New `path_matches_pattern`: a `/`-separated pattern matches only whole, consecutive path components; a trailing slash requires at least one following component. `tests/` no longer matches `src/attests/mod.rs`, and ignore pattern `src/gen` no longer swallows `src/generic.rs`.
- Applied to `is_example_path`, `is_bench_path`, `is_test_path`, `Config::is_test_path` and `Config::should_ignore`.
- New `Config::matched_ignore_pattern` returns the pattern that matched; the mapper uses it for the skip reason instead of re-implementing matching with a lossy `unwrap_or_default` fallback.

## Tests

Component-boundary tests (`src/attests/`, `src/contests/`, `src/benches_util/`), pattern rules (dir-only trailing slash, file vs dir, empty pattern), plus doctests on the new APIs.