### PR TITLE
#43 fix: remove no-op ignore-authors flag, flush stdout, accept non-UTF-8 diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ rust-diff-analyzer --diff-file changes.diff --max-units 50 --max-score 200 --max
 # Don't exit with code 1 when limits exceeded (useful in scripts)
 rust-diff-analyzer --diff-file changes.diff --no-fail
 
-# Ignore specific authors (comma-separated)
-rust-diff-analyzer --diff-file changes.diff --ignore-authors "dependabot[bot],github-actions[bot]"
+# Author filtering (ignored_authors) is applied by the GitHub Action,
+# which skips analysis when every PR commit comes from an ignored author.
 
 # Different output formats
 rust-diff-analyzer --diff-file changes.diff --format json      # Machine-readable JSON

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -3,7 +3,7 @@
 
 use std::{
     fs,
-    io::{self, Read},
+    io::{self, Read, Write},
     path::{Path, PathBuf},
     process,
 };
@@ -56,13 +56,6 @@ struct Args {
     /// Don't exit with code 1 when limits are exceeded
     #[arg(long)]
     no_fail: bool,
-
-    /// Authors to ignore (comma-separated list)
-    ///
-    /// Changes from these authors will be excluded from analysis.
-    /// Example: --ignore-authors "dependabot[bot],github-actions[bot]"
-    #[arg(long, value_delimiter = ',')]
-    ignore_authors: Option<Vec<String>>,
 }
 
 #[derive(clap::ValueEnum, Clone, Debug)]
@@ -115,11 +108,6 @@ fn run() -> Result<(), AppError> {
         config.limits.max_prod_lines = Some(max_lines);
     }
 
-    // Apply CLI ignore_authors (overrides config file)
-    if let Some(authors) = args.ignore_authors {
-        config.classification.ignored_authors = authors;
-    }
-
     config.validate()?;
 
     let diff_content = read_diff(&args.diff_file)?;
@@ -166,6 +154,9 @@ fn run() -> Result<(), AppError> {
 
     let output = format_output(&result, &config)?;
     print!("{}", output);
+    io::stdout()
+        .flush()
+        .map_err(|e| AppError::from(rust_diff_analyzer::error::IoError(e)))?;
 
     if result.summary.exceeds_limit && config.limits.fail_on_exceed && !args.no_fail {
         process::exit(1);
@@ -174,17 +165,21 @@ fn run() -> Result<(), AppError> {
     Ok(())
 }
 
+/// Reads the diff as bytes and converts lossily to UTF-8
+///
+/// `git diff` embeds raw file content, so a single non-UTF-8 line (e.g. a
+/// Latin-1 fixture) must not abort the whole analysis.
 fn read_diff(path: &Option<PathBuf>) -> Result<String, AppError> {
     match path {
-        Some(p) => {
-            fs::read_to_string(p).map_err(|e| AppError::from(FileReadError::new(p.clone(), e)))
-        }
+        Some(p) => fs::read(p)
+            .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+            .map_err(|e| AppError::from(FileReadError::new(p.clone(), e))),
         None => {
-            let mut buffer = String::new();
+            let mut buffer = Vec::new();
             io::stdin()
-                .read_to_string(&mut buffer)
+                .read_to_end(&mut buffer)
                 .map_err(|e| AppError::from(rust_diff_analyzer::error::IoError(e)))?;
-            Ok(buffer)
+            Ok(String::from_utf8_lossy(&buffer).into_owned())
         }
     }
 }


### PR DESCRIPTION
Closes #43

## What

- **Removed the `--ignore-authors` CLI flag**: it only wrote into the config and nothing in the binary or library pipeline ever consumed it — a unified diff carries no author information, so the flag physically cannot filter anything. Author filtering lives in the GitHub Action (fixed in #42); the `ignored_authors` config field stays for that. README updated. This is a breaking CLI change, scheduled for the next major release.
- **Stdout is flushed before `process::exit(1)`**: `process::exit` skips buffer flushing, so with JSON output on a limit-exceeding PR the tail of the JSON could be lost exactly on the failing path.
- **Non-UTF-8 diffs are accepted**: the diff (file or stdin) is read as bytes and converted lossily. `git diff` embeds raw file content, so one Latin-1/CP1251 line no longer aborts the whole analysis. Verified end-to-end with a Latin-1 hunk piped through the release binary.