### PR TITLE
#53 refactor: write-based output formatting and parser header cleanups

### DIFF
--- a/src/analysis/ast_visitor.rs
+++ b/src/analysis/ast_visitor.rs
@@ -223,11 +223,11 @@ impl SemanticUnitVisitor {
     ) {
         let mut attributes = self.extract_attributes(attrs);
 
-        if self.in_test_module && !attributes.contains(&"cfg_test".to_string()) {
+        if self.in_test_module && !attributes.iter().any(|a| a == "cfg_test") {
             attributes.push("cfg_test".to_string());
         }
 
-        if self.has_test_attribute(attrs) && !attributes.contains(&"test".to_string()) {
+        if self.has_test_attribute(attrs) && !attributes.iter().any(|a| a == "test") {
             attributes.push("test".to_string());
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -324,7 +324,6 @@ impl Config {
             .into());
         }
 
-        // Validate ignored_authors - check for duplicates
         let mut seen = std::collections::HashSet::new();
         for author in &self.classification.ignored_authors {
             if author.is_empty() {

--- a/src/git/diff_parser.rs
+++ b/src/git/diff_parser.rs
@@ -397,33 +397,33 @@ fn parse_diff_header(line: &str) -> Result<PathBuf, AppError> {
 }
 
 fn parse_hunk_header(line: &str) -> Result<(usize, usize, usize, usize), AppError> {
-    let line = line
+    let invalid_header = || {
+        AppError::from(DiffParseError {
+            message: format!("invalid hunk header: {}", line),
+        })
+    };
+
+    let ranges = line
         .strip_prefix("@@")
-        .and_then(|s| s.split("@@").next())
-        .ok_or_else(|| {
-            AppError::from(DiffParseError {
-                message: format!("invalid hunk header: {}", line),
-            })
-        })?
+        .ok_or_else(invalid_header)?
+        .split("@@")
+        .next()
+        .unwrap_or("")
         .trim();
 
-    let parts: Vec<&str> = line.split_whitespace().collect();
-    if parts.len() < 2 {
-        return Err(DiffParseError {
-            message: format!("invalid hunk header: {}", line),
-        }
-        .into());
-    }
+    let mut parts = ranges.split_whitespace();
+    let old_part = parts.next().ok_or_else(invalid_header)?;
+    let new_part = parts.next().ok_or_else(invalid_header)?;
 
-    let old_range = parts[0].strip_prefix('-').ok_or_else(|| {
+    let old_range = old_part.strip_prefix('-').ok_or_else(|| {
         AppError::from(DiffParseError {
-            message: format!("invalid old range: {}", parts[0]),
+            message: format!("invalid old range: {}", old_part),
         })
     })?;
 
-    let new_range = parts[1].strip_prefix('+').ok_or_else(|| {
+    let new_range = new_part.strip_prefix('+').ok_or_else(|| {
         AppError::from(DiffParseError {
-            message: format!("invalid new range: {}", parts[1]),
+            message: format!("invalid new range: {}", new_part),
         })
     })?;
 
@@ -434,22 +434,24 @@ fn parse_hunk_header(line: &str) -> Result<(usize, usize, usize, usize), AppErro
 }
 
 fn parse_range(range: &str) -> Result<(usize, usize), AppError> {
-    let parts: Vec<&str> = range.split(',').collect();
+    let (start_part, count_part) = match range.split_once(',') {
+        Some((start, count)) => (start, Some(count)),
+        None => (range, None),
+    };
 
-    let start = parts[0].parse::<usize>().map_err(|_| {
+    let start = start_part.parse::<usize>().map_err(|_| {
         AppError::from(DiffParseError {
-            message: format!("invalid line number: {}", parts[0]),
+            message: format!("invalid line number: {}", start_part),
         })
     })?;
 
-    let count = if parts.len() > 1 {
-        parts[1].parse::<usize>().map_err(|_| {
+    let count = match count_part {
+        Some(count) => count.parse::<usize>().map_err(|_| {
             AppError::from(DiffParseError {
-                message: format!("invalid line count: {}", parts[1]),
+                message: format!("invalid line count: {}", count),
             })
-        })?
-    } else {
-        1
+        })?,
+        None => 1,
     };
 
     Ok((start, count))

--- a/src/output/formatter.rs
+++ b/src/output/formatter.rs
@@ -66,46 +66,49 @@ pub fn format_output(result: &AnalysisResult, config: &Config) -> Result<String,
 }
 
 fn format_human(result: &AnalysisResult, _config: &Config) -> Result<String, AppError> {
+    use std::fmt::Write;
+
+    let summary = &result.summary;
     let mut output = String::new();
 
     output.push_str("=== Rust Diff Analysis ===\n\n");
 
     output.push_str("Production:\n");
-    output.push_str(&format!("  Functions: {}\n", result.summary.prod_functions));
-    output.push_str(&format!("  Structs: {}\n", result.summary.prod_structs));
-    output.push_str(&format!("  Other: {}\n", result.summary.prod_other));
-    output.push_str(&format!(
-        "  Lines: +{} -{}\n",
-        result.summary.prod_lines_added, result.summary.prod_lines_removed
-    ));
+    let _ = writeln!(output, "  Functions: {}", summary.prod_functions);
+    let _ = writeln!(output, "  Structs: {}", summary.prod_structs);
+    let _ = writeln!(output, "  Other: {}", summary.prod_other);
+    let _ = writeln!(
+        output,
+        "  Lines: +{} -{}",
+        summary.prod_lines_added, summary.prod_lines_removed
+    );
 
     output.push_str("\nTest:\n");
-    output.push_str(&format!("  Units: {}\n", result.summary.test_units));
-    output.push_str(&format!(
-        "  Lines: +{} -{}\n",
-        result.summary.test_lines_added, result.summary.test_lines_removed
-    ));
+    let _ = writeln!(output, "  Units: {}", summary.test_units);
+    let _ = writeln!(
+        output,
+        "  Lines: +{} -{}",
+        summary.test_lines_added, summary.test_lines_removed
+    );
 
-    output.push_str(&format!(
-        "\nWeighted score: {}\n",
-        result.summary.weighted_score
-    ));
+    let _ = writeln!(output, "\nWeighted score: {}", summary.weighted_score);
 
-    if result.summary.exceeds_limit {
+    if summary.exceeds_limit {
         output.push_str("\nLIMIT EXCEEDED\n");
     }
 
     if !result.changes.is_empty() {
         output.push_str("\nChanges:\n");
         for change in &result.changes {
-            output.push_str(&format!(
-                "  - {} ({}) in {} [+{} -{}]\n",
+            let _ = writeln!(
+                output,
+                "  - {} ({}) in {} [+{} -{}]",
                 change.unit.name,
                 change.unit.kind.as_str(),
                 change.file_path.display(),
                 change.lines_added,
                 change.lines_removed
-            ));
+            );
         }
     }
 

--- a/src/output/github.rs
+++ b/src/output/github.rs
@@ -11,45 +11,21 @@ pub struct GithubFormatter;
 
 impl Formatter for GithubFormatter {
     fn format(&self, result: &AnalysisResult, _config: &Config) -> Result<String, AppError> {
+        use std::fmt::Write;
+
+        let summary = &result.summary;
         let mut output = String::new();
 
-        output.push_str(&format!(
-            "prod_functions_changed={}\n",
-            result.summary.prod_functions
-        ));
-        output.push_str(&format!(
-            "prod_structs_changed={}\n",
-            result.summary.prod_structs
-        ));
-        output.push_str(&format!(
-            "prod_other_changed={}\n",
-            result.summary.prod_other
-        ));
-        output.push_str(&format!(
-            "test_units_changed={}\n",
-            result.summary.test_units
-        ));
-        output.push_str(&format!(
-            "prod_lines_added={}\n",
-            result.summary.prod_lines_added
-        ));
-        output.push_str(&format!(
-            "prod_lines_removed={}\n",
-            result.summary.prod_lines_removed
-        ));
-        output.push_str(&format!(
-            "test_lines_added={}\n",
-            result.summary.test_lines_added
-        ));
-        output.push_str(&format!(
-            "test_lines_removed={}\n",
-            result.summary.test_lines_removed
-        ));
-        output.push_str(&format!(
-            "weighted_score={}\n",
-            result.summary.weighted_score
-        ));
-        output.push_str(&format!("exceeds_limit={}\n", result.summary.exceeds_limit));
+        let _ = writeln!(output, "prod_functions_changed={}", summary.prod_functions);
+        let _ = writeln!(output, "prod_structs_changed={}", summary.prod_structs);
+        let _ = writeln!(output, "prod_other_changed={}", summary.prod_other);
+        let _ = writeln!(output, "test_units_changed={}", summary.test_units);
+        let _ = writeln!(output, "prod_lines_added={}", summary.prod_lines_added);
+        let _ = writeln!(output, "prod_lines_removed={}", summary.prod_lines_removed);
+        let _ = writeln!(output, "test_lines_added={}", summary.test_lines_added);
+        let _ = writeln!(output, "test_lines_removed={}", summary.test_lines_removed);
+        let _ = writeln!(output, "weighted_score={}", summary.weighted_score);
+        let _ = writeln!(output, "exceeds_limit={}", summary.exceeds_limit);
 
         Ok(output)
     }
@@ -84,12 +60,18 @@ mod tests {
             .format(&result, &config)
             .expect("format should succeed");
 
-        assert!(output.contains("prod_functions_changed=5"));
-        assert!(output.contains("prod_structs_changed=2"));
-        assert!(output.contains("prod_lines_added=50"));
-        assert!(output.contains("prod_lines_removed=20"));
-        assert!(output.contains("test_lines_added=100"));
-        assert!(output.contains("weighted_score=23"));
-        assert!(output.contains("exceeds_limit=false"));
+        let expected = concat!(
+            "prod_functions_changed=5\n",
+            "prod_structs_changed=2\n",
+            "prod_other_changed=1\n",
+            "test_units_changed=10\n",
+            "prod_lines_added=50\n",
+            "prod_lines_removed=20\n",
+            "test_lines_added=100\n",
+            "test_lines_removed=30\n",
+            "weighted_score=23\n",
+            "exceeds_limit=false\n",
+        );
+        assert_eq!(output, expected);
     }
 }


### PR DESCRIPTION
Closes #53

Follow-up to #44, split out to respect PR size limits.

- github formatter emits its key=value lines via `writeln!` into the buffer; its test now asserts the exact full output (guards against string-literal reflow corruption).
- Human formatter writes via `writeln!` instead of `push_str(&format!(...))`.
- Diff parser header parsing uses `split_once`/iterators instead of collecting `Vec`s; dead `ok_or_else` after an infallible `split().next()` removed.
- AST visitor attribute checks compare via `iter().any` instead of allocating a `String` per check.
- Removed the remaining `//` comment from a function body in config.rs.

No behavior change.