### PR TITLE
#55 chore: release v2.0.0 with updated classification docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rust-diff-analyzer"
-version = "1.6.0"
+version = "2.0.0"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-diff-analyzer"
-version = "1.6.0"
+version = "2.0.0"
 edition = "2024"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
 description = "Semantic analyzer for Rust PR diffs that distinguishes production code from test code"

--- a/README.md
+++ b/README.md
@@ -342,9 +342,10 @@ The analyzer automatically classifies code into categories:
 
 ### Classification Rules
 
-1. **File path**: Code in `tests/`, `benches/`, or `examples/` directories is not production
-2. **Attributes**: Functions with `#[test]`, `#[bench]`, or `#[cfg(test)]` are tests
-3. **Module context**: Code inside `mod tests { }` blocks is test code
+1. **File path**: Code in `tests/`, `benches/`, or `examples/` directories is not production. Patterns match whole path components, so `src/attests/mod.rs` is not mistaken for test code and an ignore pattern `src/gen` does not swallow `src/generic.rs`.
+2. **Attributes**: Functions with `#[test]`, `#[bench]`, or multi-segment test macros such as `#[tokio::test]` are tests. `cfg` predicates are parsed structurally: `#[cfg(test)]` and `#[cfg(any(test, ...))]` mark test code, while `#[cfg(not(test))]` stays production. `#[cfg(feature = "...")]` gates are matched against the configured `test_features`.
+3. **Module and impl context**: Code inside `mod tests { }`, `#[cfg(test)] mod` blocks, or `#[cfg(test)] impl` blocks is test code.
+4. **Robustness**: Deleted, unreadable, and unparsable files are skipped and reported in the analysis scope instead of failing the run; renames, quoted paths, and non-UTF-8 diff content are handled.
 
 ### Classification Types
 


### PR DESCRIPTION
Closes #55

Wraps up the bug-fix series #39, #40, #41, #42, #43, #44, #48, #53.

- README Code Classification rules updated to match fixed behavior: component-based path matching, structural cfg parsing (`cfg(not(test))` = production), multi-segment test attributes, `test_features` matching, `#[cfg(test)]` impl propagation, and skip-and-report robustness for deleted/unreadable/unparsable files.
- Version bumped to **2.0.0** (auto-tag on merge). Breaking changes per semver:
  - new `ExclusionReason` variants (`Deleted`, `ReadError`, `ParseError`) and new public field `FileDiff::is_deleted`;
  - removed the no-op `--ignore-authors` CLI flag;
  - `map_changes` records per-file failures in scope instead of returning an error;
  - PR comment kind naming unified with `SemanticUnitKind::as_str` (`type` → `type_alias`).