### PR TITLE
#57 ci: tag the triggering commit so release pipeline is not skip-ci suppressed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,13 +295,16 @@ jobs:
       - name: Create and push tag
         if: steps.check_tag.outputs.exists == 'false'
         run: |
+          # Tag the commit that triggered this run (the PR merge commit).
+          # Tagging the pulled main HEAD would land on the changelog bot's
+          # "[skip ci]" commit, and a tag push targeting a [skip ci] commit
+          # never triggers the tag-driven release jobs.
           TAG="v${{ steps.version.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git pull --rebase origin main
-          git tag -a "$TAG" -m "Release $TAG"
+          git tag -a "$TAG" -m "Release $TAG" "$GITHUB_SHA"
           git push origin "$TAG"
-          echo "Created and pushed tag $TAG"
+          echo "Created and pushed tag $TAG for $GITHUB_SHA"
 
   # Release jobs - only on tag push
   release-build:


### PR DESCRIPTION
Closes #57

The Auto Tag Release job rebased onto the newest main before tagging, so the tag landed on the changelog bot's `docs: update changelog [skip ci]` commit. GitHub suppresses workflow runs for tag pushes targeting a `[skip ci]` commit, so the tag-driven release jobs (binary builds, GitHub Release, crates.io publish) never started — v2.0.0 got a tag but no release.

The job now tags `GITHUB_SHA` — the PR merge commit that triggered the run, which never carries `[skip ci]` — and drops the rebase.