### PR TITLE
#59 chore: release v2.0.1 through the fixed tag pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rust-diff-analyzer"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-diff-analyzer"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
 description = "Semantic analyzer for Rust PR diffs that distinguishes production code from test code"


### PR DESCRIPTION
Closes #59

v2.0.0 got a tag but no release (skip-ci suppression, fixed in #57). The v2.0.0 tag points at a `[skip ci]` commit and cannot trigger the release jobs, so v2.0.1 ships the 2.x release through the fixed pipeline instead of force-moving the tag. Content is identical to v2.0.0 plus the CI fix.